### PR TITLE
Rydder opp i miljøvariabler.

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -33,8 +33,6 @@ jobs:
       contents: write
     env:
       NODE_AUTH_TOKEN: ${{ secrets.READER_TOKEN }}
-      FHIR_API_CLIENT_ID: ${{ secrets.FHIR_API_CLIENT_ID }}
-      FHIR_SUBSCRIPTION_KEY: ${{ secrets.FHIR_SUBSCRIPTION_KEY }}
     outputs:
       TAG: ${{ steps.docker-tag.outputs.TAG }}
     steps:

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -11,6 +11,7 @@
     "api.dips.no"
   ],
   "env": {
-    "FHIR_BASE_URL": "https://api.dips.no/fhir"
+    "FHIR_BASE_URL": "https://api.dips.no/fhir",
+    "FHIR_CLIENT_ID": "NAV_legeerklaering"
   }
 }

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -8,6 +8,7 @@
     "https://k9-legeerklaering.ekstern.nav.no"
   ],
   "env": {
-    "FHIR_BASE_URL": "https://api.dips.no/fhir"
+    "FHIR_BASE_URL": "https://api.dips.no/fhir",
+    "FHIR_CLIENT_ID": "NAV_legeerklaering"
   }
 }

--- a/src/app/api/fhir/Organization/[id]/route.ts
+++ b/src/app/api/fhir/Organization/[id]/route.ts
@@ -10,12 +10,12 @@ import { logRequest, logResponse } from '@/utils/loggerUtils';
 export const GET = async (request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse<IOrganization>> => {
     logRequest(request)
     const authorization = headers().get(FHIR_AUTHORIZATION_TOKEN);
-    const {fhirbaseurl, fhirsubscriptionkey} = new FhirConfiguration();
+    const {fhirBaseUrl, fhirSubscriptionKey} = new FhirConfiguration();
 
-    const response = await fetch(`${fhirbaseurl}/Organization/${params.id}`, {
+    const response = await fetch(`${fhirBaseUrl}/Organization/${params.id}`, {
         headers: {
             "Authorization": authorization!!,
-            "dips-subscription-key": fhirsubscriptionkey
+            "dips-subscription-key": fhirSubscriptionKey
         }
     });
 

--- a/src/app/api/fhir/Patient/[id]/route.ts
+++ b/src/app/api/fhir/Patient/[id]/route.ts
@@ -10,12 +10,12 @@ import { logRequest, logResponse } from '@/utils/loggerUtils';
 export const GET = async (request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse<IPatient>> => {
     logRequest(request)
     const authorization = headers().get(FHIR_AUTHORIZATION_TOKEN);
-    const {fhirbaseurl, fhirsubscriptionkey} = new FhirConfiguration();
+    const {fhirBaseUrl, fhirSubscriptionKey} = new FhirConfiguration();
 
-    const response = await fetch(`${fhirbaseurl}/Patient/${params.id}`, {
+    const response = await fetch(`${fhirBaseUrl}/Patient/${params.id}`, {
         headers: {
             "Authorization": authorization!!,
-            "dips-subscription-key": fhirsubscriptionkey
+            "dips-subscription-key": fhirSubscriptionKey
         }
     });
 

--- a/src/app/api/fhir/Practitioner/[id]/route.ts
+++ b/src/app/api/fhir/Practitioner/[id]/route.ts
@@ -11,12 +11,12 @@ import { logRequest, logResponse } from '@/utils/loggerUtils';
 export const GET = async (request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse<IPractitioner>> => {
     logRequest(request)
     const authorization = headers().get(FHIR_AUTHORIZATION_TOKEN);
-    const {fhirbaseurl, fhirsubscriptionkey} = new FhirConfiguration();
+    const {fhirBaseUrl, fhirSubscriptionKey} = new FhirConfiguration();
 
-    const response = await fetch(`${fhirbaseurl}/Practitioner/${params.id}`, {
+    const response = await fetch(`${fhirBaseUrl}/Practitioner/${params.id}`, {
         headers: {
             "Authorization": authorization!!,
-            "dips-subscription-key": fhirsubscriptionkey
+            "dips-subscription-key": fhirSubscriptionKey
         }
     });
 

--- a/src/app/api/fhir/PractitionerRole/getCurrentUser/route.ts
+++ b/src/app/api/fhir/PractitionerRole/getCurrentUser/route.ts
@@ -12,12 +12,12 @@ import Bundle = fhirclient.FHIR.Bundle;
 export const GET = async (request: NextRequest): Promise<NextResponse<IPractitionerRole | Error>> => {
     logRequest(request)
     const authorization = headers().get(FHIR_AUTHORIZATION_TOKEN)!!;
-    const {fhirbaseurl, fhirsubscriptionkey} = new FhirConfiguration();
+    const {fhirBaseUrl, fhirSubscriptionKey} = new FhirConfiguration();
 
-    const response = await fetch(`${fhirbaseurl}/PractitionerRole/$getCurrentUser`, {
+    const response = await fetch(`${fhirBaseUrl}/PractitionerRole/$getCurrentUser`, {
         headers: {
             "Authorization": authorization,
-            "dips-subscription-key": fhirsubscriptionkey
+            "dips-subscription-key": fhirSubscriptionKey
         }
     });
 

--- a/src/integrations/fhir/FhirConfiguration.ts
+++ b/src/integrations/fhir/FhirConfiguration.ts
@@ -1,31 +1,46 @@
 import { logger } from '@navikt/next-logger';
 
 export class FhirConfiguration {
-    private _fhirbaseurl: string;
-    private _fhirsubscriptionkey: string;
+    private _fhirBaseUrl: string;
+    private _fhirClientId: string;
+    private _fhirSubscriptionKey: string;
 
-    get fhirbaseurl(): string {
-        return this._fhirbaseurl;
+    get fhirBaseUrl(): string {
+        return this._fhirBaseUrl;
     }
 
-    get fhirsubscriptionkey(): string {
-        return this._fhirsubscriptionkey;
+    get fhirClientId(): string {
+        return this._fhirClientId;
+    }
+
+    get fhirSubscriptionKey(): string {
+        return this._fhirSubscriptionKey;
     }
 
     constructor() {
-        const {FHIR_BASE_URL, FHIR_SUBSCRIPTION_KEY} = process.env;
+        const {FHIR_BASE_URL, FHIR_CLIENT_ID, FHIR_SUBSCRIPTION_KEY} = process.env;
         if (!FHIR_BASE_URL) {
-            const error = new Error("FHIR_BASE_URL is not defined.");
-            logger.error(error);
-            throw error;
+            const fhirbaseurlMissing = new Error("FHIR_BASE_URL is not defined.");
+            logger.error(fhirbaseurlMissing);
+            throw fhirbaseurlMissing;
         }
-        this._fhirbaseurl = FHIR_BASE_URL;
+        this._fhirBaseUrl = FHIR_BASE_URL;
+        logger.info(`FHIR_BASE_URL --> ${this._fhirBaseUrl}`);
+
+        if (!FHIR_CLIENT_ID) {
+            const fhirClientIdMissing = new Error("FHIR_CLIENT_ID is not defined.");
+            logger.error(fhirClientIdMissing);
+            throw fhirClientIdMissing;
+        }
+        this._fhirClientId = FHIR_CLIENT_ID;
+        logger.info(`FHIR_CLIENT_ID --> ${this._fhirClientId}`);
 
         if (!FHIR_SUBSCRIPTION_KEY) {
-            const error1 = new Error("FHIR_SUBSCRIPTION_KEY is not defined.");
-            logger.error(error1);
-            throw error1;
+            const fhirsubscriptionkeyMissing = new Error("FHIR_SUBSCRIPTION_KEY is not defined.");
+            logger.error(fhirsubscriptionkeyMissing);
+            throw fhirsubscriptionkeyMissing;
         }
-        this._fhirsubscriptionkey = FHIR_SUBSCRIPTION_KEY;
+        this._fhirSubscriptionKey = FHIR_SUBSCRIPTION_KEY;
+        logger.info("FHIR_SUBSCRIPTION_KEY --> ***************");
     }
 }

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,25 +1,7 @@
 'use server'
 
-/**
- * Authparams that should work in the "EHR launch" setting which we expect to operate.
- *
- * All other params are then expected to come in via request url query arguments from the EHR browser launch, and we expect
- * that the auth flow should be displayed in the same browser window, so we don't set the target option, and therefore don't
- * need to set the completeInTarget option or any of the width or height options either.
- */
+import { FhirConfiguration } from '@/integrations/fhir/FhirConfiguration';
+
 export const fhirClientId = async (): Promise<string> => {
-    const clientId = process.env.FHIR_CLIENT_ID as string;
-    if (!clientId) {
-        throw new Error("Missing clientId in fhirClientConfig")
-    }
-
-    return clientId
-}
-
-export const fhirSubscriptionKey = async (): Promise<string> => {
-    const fhirsubscriptionkey = process.env.FHIR_SUBSCRIPTION_KEY;
-    if (!fhirsubscriptionkey || fhirsubscriptionkey.trim() === "") {
-        throw new Error("FHIR_SUBSCRIPTION_KEY is not defined or is empty")
-    }
-    return fhirsubscriptionkey
+    return new FhirConfiguration().fhirClientId
 }


### PR DESCRIPTION
- Flytter FHIR_CLIENT_ID ut fra secrets og til env.
- Fjerner FHIR_API_CLIENT_ID og FHIR_SUBSCRIPTION_KEY fra build da de kan plukkes opp ved kjøretid.
- Logger ikke-hemmelige miljøvariabler.