### PR TITLE
TSF-3861 Mangler feilmelding hvis diagnosekoder mangler

### DIFF
--- a/src/app/components/legeerklaering/LegeerklaeringForm.tsx
+++ b/src/app/components/legeerklaering/LegeerklaeringForm.tsx
@@ -320,10 +320,10 @@ export default function LegeerklaeringForm({doctor, hospital, onFormSubmit, pati
                 <Controller
                     control={control}
                     name="hoveddiagnose"
-                    render={({field: {onChange, value}}) => {
-                        return <HoveddiagnoseSelect className="mb-4" value={value} onChange={onChange}
+                    render={({field: {onChange, value}}) => (
+                        <HoveddiagnoseSelect className="mb-4" value={value} onChange={onChange}
                                              error={errors.hoveddiagnose?.code?.message || errors.hoveddiagnose?.text?.message}/>
-                    }}
+                    )}
                 />
 
                 <Controller

--- a/src/app/components/legeerklaering/LegeerklaeringForm.tsx
+++ b/src/app/components/legeerklaering/LegeerklaeringForm.tsx
@@ -116,7 +116,7 @@ const schema: ObjectSchema<LegeerklaeringData> = yup.object({
         }).required()
     }),
     hoveddiagnose: yup.object().required(tekst("legeerklaering.diagnose.hoveddiagnose.paakrevd")),
-    bidiagnoser: yup.array().of(diagnosekodeValidation).required(),
+    bidiagnoser: yup.array().min(1, tekst("legeerklaering.diagnose.bidiagnoser.paakrevd")),
     vurderingAvBarnet: yup.string().trim().required(tekst("legeerklaering.legens-vurdering.barn.paakrevd")),
     vurderingAvOmsorgspersoner: yup.string().trim().required(tekst("legeerklaering.legens-vurdering.omsorgsperson.paakrevd")),
     tilsynPeriode: tilsynsPeriodValidation,

--- a/src/app/components/legeerklaering/LegeerklaeringForm.tsx
+++ b/src/app/components/legeerklaering/LegeerklaeringForm.tsx
@@ -47,11 +47,6 @@ function undefinedIfNull<T>(something: T | undefined | null): T | undefined {
     return something
 }
 
-const diagnosekodeValidation: ObjectSchema<Diagnosekode> = yup.object({
-    code: yup.string().required().min(4).max(10),
-    text: yup.string().required()
-})
-
 const tilsynsPeriodValidation: ObjectSchema<DatePeriod> = yup.object({
     start: yup.date().required("Fra dato er påkrevd"),
     end: yup.date().required("Til dato er påkrevd"),
@@ -120,7 +115,7 @@ const schema: ObjectSchema<LegeerklaeringData> = yup.object({
             city: yup.string().required(tekst("legeerklaering.om-sykehuset.poststed.paakrevd")),
         }).required()
     }),
-    hoveddiagnose: diagnosekodeValidation.optional().default(undefined),
+    hoveddiagnose: yup.object().required(tekst("legeerklaering.diagnose.hoveddiagnose.paakrevd")),
     bidiagnoser: yup.array().of(diagnosekodeValidation).required(),
     vurderingAvBarnet: yup.string().trim().required(tekst("legeerklaering.legens-vurdering.barn.paakrevd")),
     vurderingAvOmsorgspersoner: yup.string().trim().required(tekst("legeerklaering.legens-vurdering.omsorgsperson.paakrevd")),

--- a/src/app/components/legeerklaering/LegeerklaeringForm.tsx
+++ b/src/app/components/legeerklaering/LegeerklaeringForm.tsx
@@ -13,25 +13,25 @@ import {
     useDatepicker,
     VStack
 } from '@navikt/ds-react';
-import { Controller, SubmitErrorHandler, useForm } from 'react-hook-form';
+import {Controller, SubmitErrorHandler, useForm} from 'react-hook-form';
 import Section from '@/app/components/Section';
-import { tekst } from '@/utils/tekster';
+import {tekst} from '@/utils/tekster';
 import HoveddiagnoseSelect from "@/app/components/diagnosekoder/HoveddiagnoseSelect";
 import BidiagnoseSelect from "@/app/components/diagnosekoder/BidiagnoseSelect";
 import Practitioner from "@/models/Practitioner";
 import Patient from "@/models/Patient";
 import Hospital from "@/models/Hospital";
 import * as yup from "yup";
-import { ObjectSchema } from "yup";
-import { type Diagnosekode } from "@navikt/diagnosekoder";
-import { yupResolver } from "@hookform/resolvers/yup";
+import {ObjectSchema} from "yup";
+import {yupResolver} from "@hookform/resolvers/yup";
 import LegeerklaeringData from "@/app/components/legeerklaering/LegeerklaeringData";
 import DatePeriod from "@/models/DatePeriod";
-import MultiDatePeriodInput, { DatePeriodInput } from "@/app/components/multidateperiod/MultiDatePeriodInput";
-import { logger } from '@navikt/next-logger';
+import MultiDatePeriodInput, {DatePeriodInput} from "@/app/components/multidateperiod/MultiDatePeriodInput";
+import {logger} from '@navikt/next-logger';
 import RelatedPerson from "@/models/RelatedPerson";
-import { componentSize } from '@/utils/constants';
-import { ChevronRightIcon } from '@navikt/aksel-icons';
+import {componentSize} from '@/utils/constants';
+import {ChevronRightIcon} from '@navikt/aksel-icons';
+import {Diagnosekode} from "@navikt/diagnosekoder";
 
 export interface EhrInfoLegeerklaeringForm {
     readonly doctor: Practitioner | undefined;
@@ -79,6 +79,16 @@ const caretakerValidation: ObjectSchema<RelatedPerson> = yup.object({
     fnr: yup.string().nullable().required()
 })
 
+const hoveddiagnoseValidator: ObjectSchema<Diagnosekode> = yup.object({
+    code: yup.string().required(tekst("legeerklaering.diagnose.hoveddiagnose.paakrevd")),
+    text: yup.string().required(tekst("legeerklaering.diagnose.hoveddiagnose.paakrevd"))
+})
+
+const bidiagnosekodeValidator: ObjectSchema<Diagnosekode> = yup.object({
+    code: yup.string().required("Bidiagnosekode er påkrevd"),
+    text: yup.string().required("Bidiagnosetekst er påkrevd"),
+})
+
 const schema: ObjectSchema<LegeerklaeringData> = yup.object({
     barn: yup.object({
         name: yup.string().trim()
@@ -115,8 +125,8 @@ const schema: ObjectSchema<LegeerklaeringData> = yup.object({
             city: yup.string().required(tekst("legeerklaering.om-sykehuset.poststed.paakrevd")),
         }).required()
     }),
-    hoveddiagnose: yup.object().required(tekst("legeerklaering.diagnose.hoveddiagnose.paakrevd")),
-    bidiagnoser: yup.array().min(1, tekst("legeerklaering.diagnose.bidiagnoser.paakrevd")),
+    hoveddiagnose: hoveddiagnoseValidator,
+    bidiagnoser: yup.array().of(bidiagnosekodeValidator).min(1, tekst("legeerklaering.diagnose.bidiagnoser.paakrevd")).default([]),
     vurderingAvBarnet: yup.string().trim().required(tekst("legeerklaering.legens-vurdering.barn.paakrevd")),
     vurderingAvOmsorgspersoner: yup.string().trim().required(tekst("legeerklaering.legens-vurdering.omsorgsperson.paakrevd")),
     tilsynPeriode: tilsynsPeriodValidation,
@@ -307,10 +317,10 @@ export default function LegeerklaeringForm({doctor, hospital, onFormSubmit, pati
                 <Controller
                     control={control}
                     name="hoveddiagnose"
-                    render={({field: {onChange, value}}) => (
-                        <HoveddiagnoseSelect className="mb-4" value={value} onChange={onChange}
-                                             error={errors.hoveddiagnose?.message}/>
-                    )}
+                    render={({field: {onChange, value}}) => {
+                        return <HoveddiagnoseSelect className="mb-4" value={value} onChange={onChange}
+                                             error={errors.hoveddiagnose?.code?.message || errors.hoveddiagnose?.text?.message}/>
+                    }}
                 />
 
                 <Controller

--- a/src/app/components/legeerklaering/legeerklaering-tekster.ts
+++ b/src/app/components/legeerklaering/legeerklaering-tekster.ts
@@ -23,7 +23,7 @@ export const LegeerklaeringTekster = {
     "legeerklaering.diagnose.hjelpetekst.tittel": "Les mer om diagnosekoder",
     "legeerklaering.diagnose.hjelpetekst": "Bruk diagnosekode fra ICD-10 hvis diagnose er satt. Hvis barnet er under utredning og det ikke er fastsatt noen diagnose trenger du ikke fylle ut dette.",
     "legeerklaering.diagnose.hoveddiagnose.label": "Hoveddiagnosekode",
-    "legeerklaering.diagnose.hoveddiagnose.paakrevd": "Hoveddiagnosekode er påkrevd",
+    "legeerklaering.diagnose.hoveddiagnose.paakrevd": "Hoveddiagnose er påkrevd",
     "legeerklaering.diagnose.bidiagnoser.label": "Bidiagnose(r)",
     "legeerklaering.diagnose.bidiagnoser.paakrevd": "Bidiagnose(r) er påkrevd",
 


### PR DESCRIPTION
Vis feilmelding hvis hoveddiagnose og/eller bidiagnose(r) mangler. Validering av subelements er fjernet siden de må velges utifra en forhåndsdefinert liste. Kanskje @josstn kan ta en vurdering på om validering av Diagnosekoder er nødvendig.