### PR TITLE
Avoid major npm updates in dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       npm:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
So that we quickly can do non-breaking updates and do the bigger ones manually.