### PR TITLE
Tsf 3837 custodian ref

### DIFF
--- a/src/app/(withApis)/document/[id]/page.tsx
+++ b/src/app/(withApis)/document/[id]/page.tsx
@@ -43,36 +43,36 @@ export default function DocumentViewPage({params}: {params: {id: string}}) {
         />
         <Box className="flex justify-center" padding={{xs: "2", md: "6"}}>
             <Page.Block width="lg">
-            <VStack gap="6">
-                <Alert variant="success">
-                    <Heading size="medium">Legeerklæring lagret</Heading>
-                    <BodyShort size="small" spacing>Legeerklæringen er nå lagret i pasientens journal.</BodyShort>
-                </Alert>
-                <Alert variant="info">
-                    <BodyShort size="small" spacing>Husk at den/de som skal søke om pleiepenger må få den overlevert elektronisk
-                        eller via papirutskrift, slik at den kan legges ved søknad til NAV.</BodyShort>
-                    <BodyShort size="small" spacing>Pdf vises under i tilfelle du ønsker å skrive den ut med en gang.</BodyShort>
-                </Alert>
                 <Box className="flex justify-center">
-                    { window.opener !== null ? // window.close doesn't work when window was not opened by script. Not sure what the case is in smart on fhir, so testing it here.
-                        <Button type="button" onClick={close} size="xsmall" variant="tertiary">Lukk fanen</Button> :
-                        <span>Lukk fanen</span>
-                    }
-                    <span>, eller gå&nbsp;</span>
-                    <NavNextLink href="/">til ny utfylling</NavNextLink>
+                    <VStack gap="6">
+                        <Alert variant="success">
+                            <Heading size="medium">Legeerklæring lagret</Heading>
+                            <BodyShort size="small" spacing>Legeerklæringen er nå lagret i pasientens journal.</BodyShort>
+                        </Alert>
+                        <Alert variant="info">
+                            <BodyShort size="small" spacing>Husk at den/de som skal søke om pleiepenger må få den overlevert elektronisk
+                                eller via papirutskrift, slik at den kan legges ved søknad til NAV.</BodyShort>
+                            <BodyShort size="small" spacing>Pdf vises under i tilfelle du ønsker å skrive den ut med en gang.</BodyShort>
+                        </Alert>
+                        <Box className="flex justify-center">
+                            { window.opener !== null ? // window.close doesn't work when window was not opened by script. Not sure what the case is in smart on fhir, so testing it here.
+                                <Button type="button" onClick={close} size="xsmall" variant="tertiary">Lukk fanen</Button> :
+                                <span>Lukk fanen</span>
+                            }
+                            <span>, eller gå&nbsp;</span>
+                            <NavNextLink href="/">til ny utfylling</NavNextLink>
+                        </Box>
+                    </VStack>
                 </Box>
-            </VStack>
             </Page.Block>
         </Box>
-        <HStack align="center" justify="center" padding="6">
-            <Page.Block width="lg">
-                <Heading size="small">Lagret PDF:</Heading>
+        <Page.Block width="lg">
+            <Heading size="small">Lagret PDF:</Heading>
             {
                 pdfBlob !== undefined ?
                     <PdfIframe pdf={pdfBlob} width="100%" height="1250px"/> :
                     <LoadingIndicator txt="Henter PDF" />
             }
-            </Page.Block>
-        </HStack>
+        </Page.Block>
     </Page>
 }

--- a/src/app/(withApis)/page.tsx
+++ b/src/app/(withApis)/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
     const handleFormSubmit = async (submittedData: LegeerklaeringDokument) => {
         if(isInited(fhirApi)) {
             const pdf = await helseOpplysningerApi.generatePdf(mapTilPSBLegeerklæringInnsending(submittedData))
-            const documentId = await fhirApi.createDocument(submittedData.barn.ehrId, submittedData.lege.practitionerRoleId!!, submittedData.sykehus.ehrId!!, submittedData.dokumentReferanse, pdf)
+            const documentId = await fhirApi.createDocument(submittedData.barn.ehrId, submittedData.lege.practitionerRoleId!!, submittedData.dokumentAnsvarlig, submittedData.dokumentReferanse, pdf)
             router.push(`/document/${documentId}`)
         } else {
             throw new Error("fhirApi not initialized, cannot submit")

--- a/src/app/components/legeerklaering/LegeerklaeringForm.tsx
+++ b/src/app/components/legeerklaering/LegeerklaeringForm.tsx
@@ -36,6 +36,8 @@ import {
     randomLegeerklaeringDokumentReferanse
 } from "@/models/LegeerklaeringDokumentReferanse";
 import { legeerklaeringDokumentReferanseSchema } from "@/models/yup/LegeerklaeringDokumentReferanseSchema";
+import { dipsDepartmentReferenceSchema } from "@/models/yup/DipsDepartmentReferenceSchema";
+import { DipsDepartmentReference } from "@/models/DipsDepartmentReference";
 
 export interface EhrInfoLegeerklaeringForm {
     readonly doctor: Practitioner | undefined;
@@ -88,9 +90,11 @@ const bidiagnosekodeValidator: ObjectSchema<Diagnosekode> = yup.object({
 })
 
 const dokumentReferanseValidator: Schema<LegeerklaeringDokumentReferanse> = legeerklaeringDokumentReferanseSchema().required();
+const dokumentAnsvarligValidator: Schema<DipsDepartmentReference> = dipsDepartmentReferenceSchema().required()
 
 const schema: ObjectSchema<LegeerklaeringDokument> = yup.object({
     dokumentReferanse: dokumentReferanseValidator,
+    dokumentAnsvarlig: dokumentAnsvarligValidator,
     barn: yup.object({
         name: yup.string().trim()
             .required(tekst("legeerklaering.om-barnet.navn.paakrevd"))
@@ -108,7 +112,8 @@ const schema: ObjectSchema<LegeerklaeringDokument> = yup.object({
         hprNumber: yup.string().required(tekst("legeerklaering.om-legen.hpr-nummer.paakrevd")),
         name: yup.string().required(tekst("legeerklaering.om-legen.navn.paakrevd")),
         activeSystemUser: yup.boolean().required("legens systemstatus (aktiv) er påkrevd"),
-        practitionerRoleId: yup.string().required("Legens practitionerRoleId er påkrevd")
+        practitionerRoleId: yup.string().required("Legens practitionerRoleId er påkrevd"),
+        departmentReference: dipsDepartmentReferenceSchema().required(),
     }),
     sykehus: yup.object({
         ehrId: yup.string().optional(),
@@ -145,6 +150,7 @@ export default function LegeerklaeringForm({doctor, hospital, onFormSubmit, pati
         resolver: yupResolver(schema),
         defaultValues: {
             dokumentReferanse: randomLegeerklaeringDokumentReferanse(),
+            dokumentAnsvarlig: doctor?.departmentReference,
             barn: {
                 name: patient?.name,
                 ehrId: patient?.ehrId,
@@ -157,6 +163,7 @@ export default function LegeerklaeringForm({doctor, hospital, onFormSubmit, pati
                 activeSystemUser: doctor?.activeSystemUser || false,
                 ehrId: doctor?.ehrId,
                 practitionerRoleId: doctor?.practitionerRoleId,
+                departmentReference: doctor?.departmentReference,
             },
             sykehus: {
                 name: hospital?.name,

--- a/src/app/simulation/fakeFhirApi1.ts
+++ b/src/app/simulation/fakeFhirApi1.ts
@@ -31,6 +31,7 @@ class Fake1FhirApi implements FhirApi {
                 ehrId: "fakedoctor-1",
                 practitionerRoleId: "pracRoleId-1",
                 activeSystemUser: true,
+                departmentReference: "Organization/afaFakeDepartment-1"
             },
             hospital: {
                 name: "Fake hospital1",

--- a/src/integrations/fhir/FhirApi.ts
+++ b/src/integrations/fhir/FhirApi.ts
@@ -1,9 +1,10 @@
 import InitData from "@/models/InitData";
 import { LegeerklaeringDokumentReferanse } from "@/models/LegeerklaeringDokumentReferanse";
+import { DipsDepartmentReference } from "@/models/DipsDepartmentReference";
 
 export interface FhirApi {
     getInitState(): Promise<InitData>;
 
-    createDocument(patientEhrId: string, practitionerRoleId: string, hospitalEhrId: string, description: LegeerklaeringDokumentReferanse, pdf: Blob): Promise<string>;
+    createDocument(patientEhrId: string, practitionerRoleId: string, custodianReference: DipsDepartmentReference, description: LegeerklaeringDokumentReferanse, pdf: Blob): Promise<string>;
     getDocumentPdf(documentId: string): Promise<Blob>;
 }

--- a/src/integrations/fhir/ProxiedFhirClientWrapper.ts
+++ b/src/integrations/fhir/ProxiedFhirClientWrapper.ts
@@ -25,6 +25,7 @@ import { DocumentReferenceStatusKind, IBinary, IDocumentReference } from '@ahrym
 import { createAndValidateDocumentReferencePayload } from '@/integrations/fhir/utils/payloads';
 import { LegeerklaeringDokumentReferanse } from "@/models/LegeerklaeringDokumentReferanse";
 import { base64ToBlob, blobToBase64 } from "@/utils/base64";
+import { DipsDepartmentReference } from "@/models/DipsDepartmentReference";
 
 
 export default class ProxiedFhirClientWrapper implements FhirApi {
@@ -81,7 +82,8 @@ export default class ProxiedFhirClientWrapper implements FhirApi {
                 name: practitionerFromRole.name,
                 practitionerRoleId: iPractitionerRole.id,
                 activeSystemUser: practitionerFromRole.activeSystemUser === undefined ? true : practitionerFromRole.activeSystemUser,
-                organizationReference: iPractitionerRole.organization?.reference
+                organizationReference: iPractitionerRole.organization?.reference,
+                departmentReference: practitionerFromRole.departmentReference,
             }
         }
         // Practitioner role did not have complete info, try getting it from Practitioner endpoint
@@ -105,19 +107,20 @@ export default class ProxiedFhirClientWrapper implements FhirApi {
                 practitionerRoleId: iPractitionerRole.id,
                 name: mergedPractitioner.name,
                 activeSystemUser: mergedPractitioner.activeSystemUser,
-                organizationReference: iPractitionerRole.organization?.reference
+                organizationReference: iPractitionerRole.organization?.reference,
+                departmentReference: mergedPractitioner.departmentReference,
             }
         } else {
             throw new IncompletePractitioner(mergedPractitioner)
         }
     }
 
-    public async createDocument(patientEhrId: string, practitionerRoleId: string, hospitalEhrId: string, description: LegeerklaeringDokumentReferanse, pdf: Blob): Promise<string> {
+    public async createDocument(patientEhrId: string, practitionerRoleId: string, custodianReference: DipsDepartmentReference, description: LegeerklaeringDokumentReferanse, pdf: Blob): Promise<string> {
         const pdfAsBase64 = await blobToBase64(pdf);
         const documentReference = createAndValidateDocumentReferencePayload(
             patientEhrId,
             practitionerRoleId,
-            hospitalEhrId,
+            custodianReference,
             DocumentReferenceStatusKind._current,
             description,
             [

--- a/src/integrations/fhir/utils/payloads.ts
+++ b/src/integrations/fhir/utils/payloads.ts
@@ -2,6 +2,7 @@ import { DocumentReferenceStatusKind, IDocumentReference_Content } from '@ahryma
 import { validateOrThrow } from '@/integrations/fhir/fhirValidator';
 import { R4 } from '@ahryman40k/ts-fhir-types';
 import { LegeerklaeringDokumentReferanse } from "@/models/LegeerklaeringDokumentReferanse";
+import { DipsDepartmentReference } from "@/models/DipsDepartmentReference";
 
 // Viss oppretting av DocumentReference returnerer feilmelding
 // (This document can not be saved without having EPR groups set.), så kan det vere pga feil i oppsett av brukertilgang.
@@ -10,7 +11,7 @@ const dipsDokumentType = "-1001535"
 export const createAndValidateDocumentReferencePayload = (
     patientIdentifier: string,
     practitionerRoleIdentifier: string,
-    organizationIdentifier: string,
+    custodianReference: DipsDepartmentReference,
     documentReferenceStatus: DocumentReferenceStatusKind,
     description: LegeerklaeringDokumentReferanse,
     content: Array<IDocumentReference_Content>
@@ -35,8 +36,7 @@ export const createAndValidateDocumentReferencePayload = (
             }
         ],
         "custodian": {
-            // TODO: This should be changed to the department identifier for the practitioner
-            "reference": `Organization/afa1000145`
+            "reference": custodianReference
         },
         "description": description,
         "content": content

--- a/src/models/DipsDepartmentReference.ts
+++ b/src/models/DipsDepartmentReference.ts
@@ -1,0 +1,6 @@
+
+export const dipsDepartmentReferencePrefix = "Organization/afa"
+
+export type DipsDepartmentReference = `${typeof dipsDepartmentReferencePrefix}${string}`;
+
+export const isDipsDepartmentReference = (str: string): str is DipsDepartmentReference => str.startsWith(dipsDepartmentReferencePrefix)

--- a/src/models/LegeerklaeringDokument.ts
+++ b/src/models/LegeerklaeringDokument.ts
@@ -4,6 +4,7 @@ import Practitioner from "@/models/Practitioner";
 import Hospital from "@/models/Hospital";
 import { type Diagnosekode } from '@navikt/diagnosekoder'
 import { LegeerklaeringDokumentReferanse } from "@/models/LegeerklaeringDokumentReferanse";
+import { DipsDepartmentReference } from "@/models/DipsDepartmentReference";
 
 export default interface LegeerklaeringDokument {
     readonly dokumentReferanse: LegeerklaeringDokumentReferanse;
@@ -16,4 +17,5 @@ export default interface LegeerklaeringDokument {
     innleggelsesPerioder: DatePeriod[];
     lege: Practitioner;
     sykehus: Hospital;
+    readonly dokumentAnsvarlig: DipsDepartmentReference;
 }

--- a/src/models/Practitioner.ts
+++ b/src/models/Practitioner.ts
@@ -1,4 +1,5 @@
 import { HprNumber } from "@/models/HprNumber";
+import { DipsDepartmentReference } from "@/models/DipsDepartmentReference";
 
 export default interface Practitioner {
     readonly ehrId: string;
@@ -6,7 +7,9 @@ export default interface Practitioner {
     readonly practitionerRoleId: string | undefined;
     readonly name: string;
     readonly activeSystemUser: boolean;
-
+    // If the users practitionerRole is connected to a department, its reference is set here.
+    // This is then used as a default value for custodian on created documents.
+    readonly departmentReference: DipsDepartmentReference | undefined;
 }
 
 /**

--- a/src/models/yup/DipsDepartmentReferenceSchema.ts
+++ b/src/models/yup/DipsDepartmentReferenceSchema.ts
@@ -1,0 +1,10 @@
+import { StringSchema } from "yup";
+import { DipsDepartmentReference, isDipsDepartmentReference } from "@/models/DipsDepartmentReference";
+
+export class DipsDepartmentReferenceSchema extends StringSchema<DipsDepartmentReference> {
+    override isType(v: unknown): v is DipsDepartmentReference {
+        return typeof v === 'string' && isDipsDepartmentReference(v)
+    }
+}
+
+export const dipsDepartmentReferenceSchema = () => new DipsDepartmentReferenceSchema()


### PR DESCRIPTION
Med denne endring får vi satt "dokument ansvarlig" på oppretta legeerklæringsdokument korrekt i DIPS.

Dokument ansvarlig skal vere ein referanse til ei avdeling på sjukehuset. Det blir med denne endring satt til den avdeling som brukaren har valgt å representere ved innlogging viss den info finnast. Viss ikkje blir den satt til den avdeling brukaren er tilsett ved (hovedsaklig).